### PR TITLE
fix(ci): Correct CI/CD pipeline configuration

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,9 +16,13 @@ on:
         - staging
         - production
 
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
 env:
   NODE_VERSION: '20'
-  PNPM_VERSION: '8'
   REGISTRY_URL: ${{ secrets.CONTAINER_REGISTRY_URL }}
   IMAGE_NAME: cloudide-app
 
@@ -68,28 +72,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup PNPM
-        uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
+          cache: 'npm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: npm ci
 
       - name: Lint code
-        run: pnpm lint
+        run: npm run lint
 
       - name: Type check
-        run: pnpm typecheck
+        run: npm run typecheck
 
       - name: Run tests
-        run: pnpm test:coverage
+        run: npm run test:coverage
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
@@ -117,22 +116,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup PNPM
-        uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
+          cache: 'npm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: npm ci
 
       - name: Build application
-        run: pnpm build
+        run: npm run build
         env:
           NODE_ENV: production
 
@@ -291,22 +285,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup PNPM
-        uses: pnpm/action-setup@v2
-        with:
-          version: ${{ env.PNPM_VERSION }}
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
+          cache: 'npm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: npm ci
 
       - name: Run E2E tests against staging
-        run: pnpm test:e2e
+        run: npm run test:e2e
         env:
           BASE_URL: https://staging.cloudide.dev
           TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
@@ -524,6 +513,7 @@ jobs:
     
     steps:
       - name: Notify Slack
+        if: secrets.SLACK_WEBHOOK_URL != ''
         uses: 8398a7/action-slack@v3
         with:
           status: custom


### PR DESCRIPTION
This commit fixes several issues in the GitHub Actions workflow:

1.  **Replaces `pnpm` with `npm`:** The workflow was incorrectly configured to use `pnpm`, while the project uses `npm`. All `pnpm` commands have been replaced with their `npm` equivalents (e.g., `npm ci`, `npm run <script>`).

2.  **Adds Security Scopes:** A top-level `permissions` block has been added to grant `security-events: write` permission. This is required for the CodeQL and Trivy scan result upload steps to function correctly.

3.  **Makes Slack Notification Optional:** The `Notify Slack` step has been made conditional. It will now only run if the `SLACK_WEBHOOK_URL` secret is present in the repository, preventing the build from failing if the secret is not configured.